### PR TITLE
PR1: Moving mesh visualization logic from MeshOptimization to OpenCvVisualizer3D.

### DIFF
--- a/include/kimera-vio/mesh/MeshOptimization.h
+++ b/include/kimera-vio/mesh/MeshOptimization.h
@@ -69,15 +69,6 @@ class MeshOptimization {
       const size_t& thickness = 1u,
       const int line_type = CV_AA);
 
-  //! Visualization functions
-  void draw3dMesh(const std::string& id,
-                  const Mesh3D& mesh_3d,
-                  bool display_as_wireframe = false,
-                  const double& opacity = 1.0);
-
-  //! Render the collected visualizations
-  void spinDisplay();
-
  public:
   // In public only for testing... please remove.
 
@@ -183,7 +174,6 @@ class MeshOptimization {
 
   /// 3D plotting
   // TODO(Toni) this should be done by the display module...
-  cv::viz::Viz3d window_;
   MeshColorType mesh_color_type_;
   OpenCvVisualizer3D::Ptr visualizer_;
 };

--- a/include/kimera-vio/visualizer/OpenCvVisualizer3D.h
+++ b/include/kimera-vio/visualizer/OpenCvVisualizer3D.h
@@ -194,6 +194,15 @@ class OpenCvVisualizer3D : public Visualizer3D {
                 const cv::Point3d& pt2,
                 WidgetsMap* widgets);
 
+  //! Mesh visualization functions
+  void draw3dMesh(const std::string& id,
+                  const Mesh3D& mesh_3d,
+                  bool display_as_wireframe = false,
+                  const double& opacity = 1.0);
+
+  //! Render the collected visualizations
+  void meshSpinDisplay();
+
  private:
   //! Create a 2D mesh from 2D corners in an image, coded as a Frame class
   static cv::Mat visualizeMesh2D(
@@ -421,6 +430,9 @@ class OpenCvVisualizer3D : public Visualizer3D {
 
   WidgetIds widget_ids_to_remove_;
   WidgetIds widget_ids_to_remove_in_next_iter_;
+
+  // Used draw3dMesh and meshSpinDisplay functions
+  cv::viz::Viz3d meshWindow_;
 
   //! Colors & Scales
   cv::viz::Color cloud_color_ = cv::viz::Color::white();

--- a/src/mesh/MeshOptimization.cpp
+++ b/src/mesh/MeshOptimization.cpp
@@ -87,41 +87,6 @@ void MeshOptimization::draw2dMeshOnImg(const Mesh2D& mesh_2d,
   }
 }
 
-void MeshOptimization::draw3dMesh(const std::string& id,
-                                  const Mesh3D& mesh_3d,
-                                  bool display_as_wireframe,
-                                  const double& opacity) {
-  cv::Mat vertices_mesh;
-  cv::Mat polygons_mesh;
-  mesh_3d.getVerticesMeshToMat(&vertices_mesh);
-  mesh_3d.getPolygonsMeshToMat(&polygons_mesh);
-  cv::Mat colors_mesh = mesh_3d.getColorsMesh().t();  // Note the transpose.
-  if (colors_mesh.empty()) {
-    colors_mesh = cv::Mat(1u,
-                          mesh_3d.getNumberOfUniqueVertices(),
-                          CV_8UC3,
-                          cv::viz::Color::yellow());
-  }
-
-  // Build visual mesh
-  cv::viz::Mesh cv_mesh;
-  cv_mesh.cloud = vertices_mesh.t();
-  cv_mesh.polygons = polygons_mesh;
-  cv_mesh.colors = colors_mesh;
-
-  // Build widget mesh
-  cv::viz::WMesh widget_cv_mesh(cv_mesh);
-  widget_cv_mesh.setRenderingProperty(cv::viz::SHADING, cv::viz::SHADING_FLAT);
-  widget_cv_mesh.setRenderingProperty(cv::viz::AMBIENT, 0);
-  widget_cv_mesh.setRenderingProperty(cv::viz::LIGHTING, 1);
-  widget_cv_mesh.setRenderingProperty(cv::viz::OPACITY, opacity);
-  if (display_as_wireframe) {
-    widget_cv_mesh.setRenderingProperty(cv::viz::REPRESENTATION,
-                                        cv::viz::REPRESENTATION_WIREFRAME);
-  }
-  window_.showWidget(id.c_str(), widget_cv_mesh);
-}
-
 void MeshOptimization::collectTriangleDataPointsFast(
     const cv::Mat& noisy_point_cloud,
     const Mesh2D& mesh_2d,
@@ -763,11 +728,6 @@ void MeshOptimization::drawPixelOnImg(const cv::Point2f& pixel,
                                       const size_t& pixel_size) {
   // Draw the pixel on the image
   cv::circle(img, pixel, pixel_size, color, -1);
-}
-
-void MeshOptimization::spinDisplay() {
-  // Display 3D window
-  window_.spin();
 }
 
 }  // namespace VIO

--- a/src/mesh/MeshOptimization.cpp
+++ b/src/mesh/MeshOptimization.cpp
@@ -53,12 +53,9 @@ MeshOptimization::MeshOptimization(const MeshOptimizerType& solver_type,
     : mesh_optimizer_type_(solver_type),
       mono_camera_(camera),
       body_pose_cam_(camera->getBodyPoseCam()),
-      window_("Mesh Optimization"),
       mesh_color_type_(mesh_color_type),
       visualizer_(visualizer) {
-  CHECK(camera);
-  window_.setBackgroundColor(cv::viz::Color::white());
-  window_.setFullScreen(true);
+  CHECK(camera);  
 }
 
 MeshOptimizationOutput::UniquePtr MeshOptimization::spinOnce(
@@ -642,11 +639,11 @@ MeshOptimizationOutput::UniquePtr MeshOptimization::solveOptimalMesh(
   // Display reconstructed mesh.
   if (visualizer_) {
     LOG(INFO) << "Drawing optimized reconstructed mesh...";
-    draw3dMesh("Reconstructed Mesh " + std::to_string(mesh_count_),
+    visualizer_->draw3dMesh("Reconstructed Mesh " + std::to_string(mesh_count_),
                reconstructed_mesh,
                false,
                0.9);
-    spinDisplay();
+    visualizer_->meshSpinDisplay();
   }
   MeshOptimizationOutput::UniquePtr mesh_output =
       std::make_unique<MeshOptimizationOutput>();

--- a/src/visualizer/OpenCvVisualizer3D.cpp
+++ b/src/visualizer/OpenCvVisualizer3D.cpp
@@ -88,7 +88,10 @@ namespace VIO {
 
 OpenCvVisualizer3D::OpenCvVisualizer3D(const VisualizationType& viz_type,
                                        const BackendType& backend_type)
-    : Visualizer3D(viz_type), backend_type_(backend_type), logger_(nullptr) {
+    : Visualizer3D(viz_type), backend_type_(backend_type), logger_(nullptr),
+      meshWindow_("Mesh Optimization") {
+  meshWindow_.setBackgroundColor(cv::viz::Color::white());
+  meshWindow_.setFullScreen(true);
   if (FLAGS_log_mesh) {
     logger_ = std::make_unique<VisualizerLogger>();
   }

--- a/src/visualizer/OpenCvVisualizer3D.cpp
+++ b/src/visualizer/OpenCvVisualizer3D.cpp
@@ -1926,6 +1926,46 @@ void OpenCvVisualizer3D::colorMeshByClusters(const std::vector<Plane>& planes,
   }
 }
 
+void OpenCvVisualizer3D::draw3dMesh(const std::string& id,
+                                  const Mesh3D& mesh_3d,
+                                  bool display_as_wireframe,
+                                  const double& opacity) {
+  cv::Mat vertices_mesh;
+  cv::Mat polygons_mesh;
+  mesh_3d.getVerticesMeshToMat(&vertices_mesh);
+  mesh_3d.getPolygonsMeshToMat(&polygons_mesh);
+  cv::Mat colors_mesh = mesh_3d.getColorsMesh().t();  // Note the transpose.
+  if (colors_mesh.empty()) {
+    colors_mesh = cv::Mat(1u,
+                          mesh_3d.getNumberOfUniqueVertices(),
+                          CV_8UC3,
+                          cv::viz::Color::yellow());
+  }
+
+  // Build visual mesh
+  cv::viz::Mesh cv_mesh;
+  cv_mesh.cloud = vertices_mesh.t();
+  cv_mesh.polygons = polygons_mesh;
+  cv_mesh.colors = colors_mesh;
+
+  // Build widget mesh
+  cv::viz::WMesh widget_cv_mesh(cv_mesh);
+  widget_cv_mesh.setRenderingProperty(cv::viz::SHADING, cv::viz::SHADING_FLAT);
+  widget_cv_mesh.setRenderingProperty(cv::viz::AMBIENT, 0);
+  widget_cv_mesh.setRenderingProperty(cv::viz::LIGHTING, 1);
+  widget_cv_mesh.setRenderingProperty(cv::viz::OPACITY, opacity);
+  if (display_as_wireframe) {
+    widget_cv_mesh.setRenderingProperty(cv::viz::REPRESENTATION,
+                                        cv::viz::REPRESENTATION_WIREFRAME);
+  }
+  meshWindow_.showWidget(id.c_str(), widget_cv_mesh);
+}
+
+void OpenCvVisualizer3D::meshSpinDisplay() {
+  // Display 3D window
+  meshWindow_.spin();
+}
+
 void OpenCvVisualizer3D::getColorById(const size_t& id,
                                       cv::viz::Color* color) const {
   CHECK_NOTNULL(color);


### PR DESCRIPTION
This is the first PR in a series of changes that aim to make building with the visualizer module optional and remove the cv::viz dependency from other modules. For low-powered production systems, this sub-system with many heavy dependencies is not desirable. However, visualization is still a useful tool to have for system tuning and development to get quick insight. 

This PR serves to move visualization code from MeshOptimization into the visualizer module, so it can be easily excluded without the use of #ifdefs throughout the MeshOptimization code. I moved the mesh visualization code into the OpenCvVisualizer3D class since this is already used by MeshOptimization. 

A caveat of this choice is that this code feels slightly out of place as it is not strictly related. Alternative options could be creating a new class specifically for mesh visualization. DisplayModule is also mentioned in a comment as a potential place for this but it also doesn’t quite fit the class description there either. 

Full design document:
[Visualization Build Option Refactor for Kimera-VIO.pdf](https://github.com/user-attachments/files/18363412/Visualization.Build.Option.Refactor.for.Kimera-VIO.pdf)

**Testing process**
*Build docker container for testing*
* Navigate to Kimera-VIO/scripts/Docker
* Modify the Dockerfile to get the relevant testing branch instead of master. Change line 85 to the following:
```
RUN git clone https://github.com/Virtana/Kimera-VIO.git && git checkout origin/<branch_name>
```
* Build and run the image: 
```
./kimera_vio_docker.bash
```

*Testing*
1. Update Kimera-VIO to generate logs:
    1. For stereo: Open `Kimera-VIO/params/Euroc/flags/stereoVIOEuroc.flags` with your editor of choice and modify `-- log_output` to true. 
    2. For mono: 
        1. Open Kimera-VIO/params/EurocMono/flags/stereoVIOEuroc.flags and modify `-- log_output` to true.
        2. Open Kimera-VIO/params/EurocMono/BackendParams.yaml with the following changes:
             * linearizationMode: 1
        3. Open Kimera-VIO/params/EurocMono/FrontendParams.yaml with the following changes:
            * maxFeatureAge: 15
            * feature_detector_type: 0
            * maxFeaturesPerFrame: 200
        4. Open Kimera-VIO/script/stereoVIOEuroc.bash and change the `LOG_OUTPUT` variable from 0 to 1.
2. Run Kimera-VIO: `./stereoVIOEuroc.bash`. 
3. You can examine output logs in Kimera-VIO/output_logs/ to ensure the values in traj_gt.csv are the same as the version on master. You can re-run after checking out to master and rebuilding and installing:
```
git checkout master
rm -r build && mkdir build
cd build
cmake .. && make -j4 install
```
Then re-run Kimera-VIO as shown in step 2. You should be re-running with the same configuration options. 

You should also be looking out for any differences in the visualizer behaviour. 
