### PR TITLE
Updated frontend logger intialisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,6 @@ add_subdirectory(src/visualizer)
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-    opengv
     DBoW2::DBoW2
     KimeraRPGO
     triangle::triangle
@@ -136,6 +135,7 @@ target_link_libraries(${PROJECT_NAME}
     ${GLOG_LIBRARIES}
     gtsam
     gtsam_unstable
+    opengv
 )
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,6 @@ find_package(GTSAM_UNSTABLE REQUIRED)
 find_package(opengv REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(DBoW2 REQUIRED)
-if(NOT TARGET DBoW2::DBoW2)
-  add_library(DBoW2::DBoW2 INTERFACE IMPORTED)
-  set_target_properties(DBoW2::DBoW2 PROPERTIES
-  INTERFACE_LINK_LIBRARIES "${DBoW2_LIBRARIES}"
-  INTERFACE_INCLUDE_DIRECTORIES "${DBoW2_INCLUDE_DIRS}")
-endif()
 find_package(KimeraRPGO REQUIRED)
 # Pangolin is optional
 find_package(Pangolin QUIET)
@@ -126,19 +120,20 @@ add_subdirectory(src/visualizer)
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-    DBoW2::DBoW2
     KimeraRPGO
     triangle::triangle
   PUBLIC
     ${OpenCV_LIBRARIES}
     ${GFLAGS_LIBRARIES}
     ${GLOG_LIBRARIES}
+    ${DBoW2_LIBRARIES}
     gtsam
     gtsam_unstable
     opengv
 )
 target_include_directories(${PROJECT_NAME}
   PUBLIC
+    ${DBoW2_INCLUDE_DIRS}
     ${OpenCV_INCLUDE_DIRS}
     ${GFLAGS_INCLUDE_DIRS}
     ${GLOG_INCLUDE_DIRS}

--- a/cmake/kimera_vioConfig.cmake.in
+++ b/cmake/kimera_vioConfig.cmake.in
@@ -8,6 +8,7 @@ find_dependency(Glog REQUIRED)
 find_dependency(GTSAM REQUIRED)
 find_dependency(GTSAM_UNSTABLE REQUIRED)
 find_dependency(OpenCV REQUIRED)
+find_dependency(opengv REQUIRED)
 
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 

--- a/cmake/kimera_vioConfig.cmake.in
+++ b/cmake/kimera_vioConfig.cmake.in
@@ -3,6 +3,7 @@ include(CMakeFindDependencyMacro)
 
 list(APPEND CMAKE_MODULE_PATH ${KimeraVIO_CMAKE_DIR})
 
+find_dependency(DBoW2 REQUIRED)
 find_dependency(Gflags REQUIRED)
 find_dependency(Glog REQUIRED)
 find_dependency(GTSAM REQUIRED)

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -413,13 +413,30 @@ FrontendLogger::FrontendLogger()
       output_frontend_img_path_(FLAGS_output_path + "/frontend_images/") {
   namespace fs = std::filesystem;
   const fs::path logger_dir(output_frontend_img_path_);
+  // Create parent directory.
   fs::create_directory(logger_dir);
-  fs::create_directory(logger_dir / "monoFeatureTracksLeftImg");
-  fs::create_directory(logger_dir / "monoTrackingUnrectifiedImg");
-  fs::create_directory(logger_dir / "monoTrackingRectifiedImg");
-  fs::create_directory(logger_dir / "stereoMatchingUnrectifiedImg");
-  fs::create_directory(logger_dir / "stereoMatchingRectifiedImg");
-  fs::create_directory(logger_dir / "rgbdDepthFeaturesImg");
+  // Initialise list of directory names to create
+  std::vector<std::string> sub_directories = {
+    "monoFeatureTracksLeftImg",
+    "monoTrackingUnrectifiedImg",
+    "monoTrackingRectifiedImg",
+    "stereoMatchingUnrectifiedImg",
+    "stereoMatchingRectifiedImg",
+    "rgbdDepthFeaturesImg"
+  };
+  // Loop through the directory names and create each directory if it doesn't exist.
+  for (const auto& sub_directory : sub_directories) {
+    std::string full_sub_dir_path = logger_dir / sub_directory;
+    if(fs::exists(full_sub_dir_path)){
+      // Iterate over the contents of the directory and remove each file.
+      for (const auto& entry : fs::directory_iterator(full_sub_dir_path)) {
+        fs::remove(entry);
+      }
+    }
+    else{
+      fs::create_directory(full_sub_dir_path);
+    }
+  }
 }
 
 void FrontendLogger::logFrontendStats(

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -413,10 +413,8 @@ FrontendLogger::FrontendLogger()
       output_frontend_img_path_(FLAGS_output_path + "/frontend_images/") {
   namespace fs = std::filesystem;
   const fs::path logger_dir(output_frontend_img_path_);
-  // Create parent directory.
-  fs::create_directory(logger_dir);
-  // Initialise list of directory names to create
-  std::vector<std::string> sub_directories = {
+  fs::create_directory(logger_dir); // Create parent directory.
+  std::vector<std::string> sub_directories = { // Initialise list of directory names to create
     "monoFeatureTracksLeftImg",
     "monoTrackingUnrectifiedImg",
     "monoTrackingRectifiedImg",
@@ -424,16 +422,16 @@ FrontendLogger::FrontendLogger()
     "stereoMatchingRectifiedImg",
     "rgbdDepthFeaturesImg"
   };
+
   // Loop through the directory names and create each directory if it doesn't exist.
   for (const auto& sub_directory : sub_directories) {
     std::string full_sub_dir_path = logger_dir / sub_directory;
-    if(fs::exists(full_sub_dir_path)){
-      // Iterate over the contents of the directory and remove each file.
+    if (fs::exists(full_sub_dir_path)) { // Iterate over the contents of the directory and remove each file.
       for (const auto& entry : fs::directory_iterator(full_sub_dir_path)) {
         fs::remove(entry);
       }
     }
-    else{
+    else {
       fs::create_directory(full_sub_dir_path);
     }
   }


### PR DESCRIPTION
### Outline
This pull request addresses an issue discovered when images are saved for purposes of investigating feature tracking in the frontend.

### Reason for change
This issue occurs when Kimera-VIO is executed consecutively with different datasets—the contents of the directories within /output_logs/frontend_images are not cleared between runs. As a result, images from previous executions can mix with the current execution, leading to misleading results.

The following sub-directories are susceptible to the issue:

monoFeatureTracksLeftImg
monoTrackingUnrectifiedImg
monoTrackingRectifiedImg
stereoMatchingUnrectifiedImg
stereoMatchingRectifiedImg
rgbdDepthFeaturesImg
Proposed fix
Erase the contents of these directories when upon starting Kimera-VIO to avoid images from consecutive runs from being mixed together.